### PR TITLE
Enable macros

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -5,6 +5,15 @@ partials:
   - type: single-column
     headline: Animation & Interface Design
     body: The New Media Arts (NMA) program is a two year AS degree program located at Kapi‘olani Community College (KCC) in Honolulu, Hawaii. The NMA mission is to prepare students for employment in the fields of interface design and animation.
+    links:
+      - label: NMA DEGREE INFO
+        # TODO: at the moment this is a hash link, but in the future it could another page
+        url: '#'
+      - label: MEET THE FACULTY
+        url: 'https://google.com'
+        target: _blank
+        variants:
+          - dark
     variants:
       - hero
 

--- a/views/elements/text-stack.njk
+++ b/views/elements/text-stack.njk
@@ -1,4 +1,5 @@
 <template id="text-stack-template">
   <h3 part="headline" class="text-stack__headline"></h3>
   <div part="body" class="text-stack__body"></div>
+  <slot name="buttons"/>
 </template>

--- a/views/macros/button.njk
+++ b/views/macros/button.njk
@@ -1,0 +1,24 @@
+{% macro render(data) %}
+    {# The default element will be a button unless a url is specified #}
+    {% set tag = 'button' %}
+
+    {% if data.url %}
+        {% set tag = 'a' %}
+    {% endif %}
+
+    <{{tag}} 
+        class="button{% for variant in data.variants %} button--{{variant}} {%- endfor %}" 
+        {% if data.url %}href="{{data.url | url}}"{% endif %}
+        {% if data.ariaLabel %}aria-label="{{data.ariaLabel}}"{% endif %}
+        {% if data.target == '_blank' %}
+           target="_blank" 
+           rel="noreferrer"
+        {% endif %}
+        >
+        {% if data.visuallyHidden %}
+            <span class="visually-hidden">{{data.label}}</span>
+        {% else %}
+            {{data.label}}
+        {% endif %}
+    </{{tag}}>
+{% endmacro %}

--- a/views/partials/single-column.njk
+++ b/views/partials/single-column.njk
@@ -1,3 +1,5 @@
+{% import "../macros/button.njk" as button %}
+
 <div class="{{partial.type}}{% for variant in partial.variants %} {{partial.type}}--{{variant}} {%- endfor %}">
   {% if partial.backgroundImage %}
     <div class="single-column__bg">
@@ -17,5 +19,11 @@
   <nma-text-stack 
     {% if partial.headline %}headline="{{partial.headline}}"{% endif %} 
     {% if partial.body %}body="{{partial.body}}"{% endif %}
-    ></nma-text-stack>
+    >
+    <div slot="buttons">
+      {% for link in partial.links %}
+        {{button.render(link)}}
+      {% endfor %}
+    </div>
+  </nma-text-stack>
 </div>


### PR DESCRIPTION
@kccnma  This branch creates the `view/macros` directory and a `button` macro.  If you look at the `views/partials/single-column.njk` file it uses the macro to render links to the `buttons` slot.

```njk
{% for link it partial.links %}
  {{button.render(link)}}
{% endfor %}
```